### PR TITLE
Add config file input.

### DIFF
--- a/Televarr/ez-iptvcat-scraper-master/configfile.yaml
+++ b/Televarr/ez-iptvcat-scraper-master/configfile.yaml
@@ -1,0 +1,16 @@
+sources:
+ -
+   name: "United Kingdon"
+   url: "https://iptvcat.com/united_kingdom"
+ -
+   name: "Canada"
+   url: "https://iptvcat.com/canada"
+ -
+   name: "USA"
+   url: "https://iptvcat.com/united_states_of_america"
+ -
+   name: "Pakistan"
+   url: "https://iptvcat.com/pakistan"
+ -
+   name: "Undefined!"
+   url: "https://iptvcat.com/undefined"

--- a/Televarr/ez-iptvcat-scraper-master/go.mod
+++ b/Televarr/ez-iptvcat-scraper-master/go.mod
@@ -14,4 +14,5 @@ require (
 	github.com/temoto/robotstxt v1.1.1 // indirect
 	golang.org/x/net v0.0.0-20200602114024-627f9648deb9 // indirect
 	google.golang.org/appengine v1.6.6 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/Televarr/ez-iptvcat-scraper-master/go.sum
+++ b/Televarr/ez-iptvcat-scraper-master/go.sum
@@ -92,4 +92,6 @@ google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCID
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=


### PR DESCRIPTION
This contribution adds a simple configuration file to the ez-iptvcat-scraper application.

The names are included in the config file, but the application doesn't use them as-is.